### PR TITLE
Upgrade Java-WebSockets

### DIFF
--- a/stomplibrary/build.gradle
+++ b/stomplibrary/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'org.java-websocket:Java-WebSocket:1.3.0'
+    compile 'org.java-websocket:Java-WebSocket:1.3.8'
     compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'io.reactivex:rxandroid:1.2.1'
     testCompile 'junit:junit:4.12'

--- a/stomplibrary/src/main/java/com/techdew/stomplibrary/WebSocketsConnectionProvider.java
+++ b/stomplibrary/src/main/java/com/techdew/stomplibrary/WebSocketsConnectionProvider.java
@@ -3,9 +3,8 @@ package com.techdew.stomplibrary;
 import android.util.Log;
 
 import org.java_websocket.WebSocket;
-import org.java_websocket.client.DefaultSSLWebSocketClientFactory;
 import org.java_websocket.client.WebSocketClient;
-import org.java_websocket.drafts.Draft_17;
+import org.java_websocket.drafts.Draft_6455;
 import org.java_websocket.exceptions.InvalidDataException;
 import org.java_websocket.handshake.ClientHandshake;
 import org.java_websocket.handshake.ServerHandshake;
@@ -74,7 +73,7 @@ public class WebSocketsConnectionProvider implements ConnectionProvider {
         if (haveConnection)
             throw new IllegalStateException("Already have connection to web socket");
 
-        mWebSocketClient = new WebSocketClient(URI.create(mUri), new Draft_17(), mConnectHttpHeaders, 0) {
+        mWebSocketClient = new WebSocketClient(URI.create(mUri), new Draft_6455(), mConnectHttpHeaders, 0) {
 
             @Override
             public void onWebsocketHandshakeReceivedAsClient(WebSocket conn, ClientHandshake request, ServerHandshake response) throws InvalidDataException {
@@ -119,7 +118,7 @@ public class WebSocketsConnectionProvider implements ConnectionProvider {
             try {
                 SSLContext sc = SSLContext.getInstance("TLS");
                 sc.init(null, null, null);
-                mWebSocketClient.setWebSocketFactory(new DefaultSSLWebSocketClientFactory(sc));
+                mWebSocketClient.setSocket(sc.getSocketFactory().createSocket());
             } catch (Exception e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
Upgraded Java-WebSockets to 1.3.8 to fix a crash when using SSL.